### PR TITLE
Handle missing state when saving popup card

### DIFF
--- a/popup/popup.js
+++ b/popup/popup.js
@@ -1,1 +1,45 @@
-import {loadState,saveState} from '../sidepanel/state.js';document.getElementById('save').addEventListener('click',async()=>{const s=await loadState();const b=s.boards.find(x=>x.id===s.activeBoardId);b.cards.push({id:crypto.randomUUID(),title:document.getElementById('title').value||'New task',columnId:b.columns[0].id});await saveState(s);window.close();});
+import { loadState, saveState, initDefault } from '../sidepanel/state.js';
+
+const saveButton = document.getElementById('save');
+
+saveButton?.addEventListener('click', async () => {
+  let state = await loadState();
+
+  if (!state || !Array.isArray(state.boards) || state.boards.length === 0) {
+    state = await initDefault();
+  }
+
+  let board = state.boards.find((candidate) => candidate.id === state.activeBoardId);
+
+  if (!board && state.boards.length > 0) {
+    board = state.boards[0];
+    state.activeBoardId = board.id;
+  }
+
+  if (!board) {
+    state = await initDefault();
+    board = state.boards[0];
+  }
+
+  if (!Array.isArray(board.columns) || board.columns.length === 0) {
+    const column = { id: crypto.randomUUID(), name: 'Backlog' };
+    board.columns = [column];
+  }
+
+  if (!Array.isArray(board.cards)) {
+    board.cards = [];
+  }
+
+  const titleInput = document.getElementById('title');
+  const title = titleInput?.value?.trim();
+  const cardTitle = title?.length ? title : 'New task';
+
+  board.cards.push({
+    id: crypto.randomUUID(),
+    title: cardTitle,
+    columnId: board.columns[0].id,
+  });
+
+  await saveState(state);
+  window.close();
+});


### PR DESCRIPTION
## Summary
- ensure the popup initializes a default board and columns when no state is stored yet
- guard against missing cards, columns, or active board when saving a new task from the popup

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e40c48e8b48328bd18409a3678511d