### PR TITLE
Restore Kanban board rendering and state tooling

### DIFF
--- a/options/options.html
+++ b/options/options.html
@@ -1,1 +1,152 @@
-<!doctype html><html><body><h2>Kanban Settings</h2><button id='export'>Export</button><input type='file' id='import' accept='application/json'><script type='module' src='options.js'></script></body></html>
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Kanban Settings</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        font-family: 'Inter', 'Segoe UI', system-ui, sans-serif;
+      }
+
+      body {
+        margin: 0;
+        padding: 32px;
+        background: #0f1115;
+        color: #e6e6e6;
+        min-height: 100vh;
+        display: flex;
+        justify-content: center;
+      }
+
+      main {
+        max-width: 520px;
+        width: 100%;
+        background: rgba(21, 24, 34, 0.92);
+        border: 1px solid #1f2330;
+        border-radius: 16px;
+        padding: 32px;
+        box-shadow: 0 24px 48px rgba(0, 0, 0, 0.35);
+      }
+
+      h1 {
+        margin: 0 0 24px;
+        font-size: 22px;
+      }
+
+      section + section {
+        margin-top: 24px;
+        padding-top: 24px;
+        border-top: 1px solid #1f2330;
+      }
+
+      h2 {
+        margin: 0 0 12px;
+        font-size: 16px;
+      }
+
+      button,
+      select,
+      input[type='file'] {
+        font: inherit;
+      }
+
+      button {
+        padding: 10px 16px;
+        border-radius: 10px;
+        border: none;
+        background: #2f80ed;
+        color: #fff;
+        font-weight: 600;
+        cursor: pointer;
+        transition: background 0.2s ease, transform 0.2s ease;
+      }
+
+      button:hover {
+        background: #4d96f3;
+      }
+
+      button:active {
+        transform: translateY(1px);
+      }
+
+      .inline-actions {
+        display: flex;
+        gap: 12px;
+        align-items: center;
+        flex-wrap: wrap;
+      }
+
+      .import-label {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        cursor: pointer;
+        color: #b5bdd3;
+      }
+
+      .import-label input[type='file'] {
+        display: none;
+      }
+
+      select {
+        appearance: none;
+        background: #151822;
+        border: 1px solid #1f2330;
+        border-radius: 10px;
+        color: inherit;
+        padding: 10px 14px;
+        min-width: 160px;
+      }
+
+      .hint {
+        margin-top: 12px;
+        font-size: 13px;
+        color: #9aa1b9;
+      }
+
+      #status {
+        margin-top: 24px;
+        min-height: 20px;
+        color: #9aa1b9;
+      }
+
+      #status.success {
+        color: #66d9a3;
+      }
+
+      #status.error {
+        color: #ff8a80;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Kanban Settings</h1>
+      <section>
+        <h2>Data management</h2>
+        <div class="inline-actions">
+          <button id="export" type="button">Export boards</button>
+          <label class="import-label">
+            <span>Import from file</span>
+            <input type="file" id="import" accept="application/json">
+          </label>
+        </div>
+        <p class="hint">Imported data is validated before it overwrites your existing boards.</p>
+      </section>
+      <section>
+        <h2>Theme</h2>
+        <label for="theme">Side panel theme</label>
+        <div class="inline-actions">
+          <select id="theme">
+            <option value="dark">Dark</option>
+            <option value="light">Light</option>
+            <option value="system">Match system</option>
+          </select>
+        </div>
+      </section>
+      <p id="status" role="status" aria-live="polite"></p>
+    </main>
+    <script type="module" src="options.js"></script>
+  </body>
+</html>

--- a/options/options.js
+++ b/options/options.js
@@ -1,1 +1,104 @@
-const KEY='kanban.v1';document.getElementById('export').addEventListener('click',async()=>{const s=(await chrome.storage.local.get(KEY))[KEY];const a=document.createElement('a');a.href=URL.createObjectURL(new Blob([JSON.stringify(s,null,2)],{type:'application/json'}));a.download='kanban.json';a.click();});
+import { loadState, saveState, initDefault, normalizeState } from '../sidepanel/state.js';
+
+const exportButton = document.getElementById('export');
+const importInput = document.getElementById('import');
+const themeSelect = document.getElementById('theme');
+const statusElement = document.getElementById('status');
+
+let state = await loadState();
+if (!state) {
+  state = await initDefault();
+}
+
+if (themeSelect) {
+  themeSelect.value = state.settings?.theme ?? 'dark';
+}
+
+if (exportButton) {
+  exportButton.addEventListener('click', handleExport);
+}
+
+if (importInput) {
+  importInput.addEventListener('change', handleImport);
+}
+
+if (themeSelect) {
+  themeSelect.addEventListener('change', handleThemeChange);
+}
+
+function announce(message, variant = 'info') {
+  if (!statusElement) {
+    return;
+  }
+  statusElement.textContent = message;
+  statusElement.classList.remove('success', 'error');
+  if (variant === 'success') {
+    statusElement.classList.add('success');
+  } else if (variant === 'error') {
+    statusElement.classList.add('error');
+  }
+}
+
+async function handleExport() {
+  const data = JSON.stringify(state, null, 2);
+  const blob = new Blob([data], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = 'kanban.json';
+  anchor.click();
+  URL.revokeObjectURL(url);
+  announce('Exported current board data.', 'success');
+}
+
+async function handleImport(event) {
+  const input = event.target;
+  const file = input.files?.[0];
+  if (!file) {
+    return;
+  }
+
+  try {
+    const text = await file.text();
+    let parsed;
+    try {
+      parsed = JSON.parse(text);
+    } catch (error) {
+      throw new Error('The selected file does not contain valid JSON.');
+    }
+
+    const { state: normalized, diagnostics } = normalizeState(parsed);
+    state = normalized;
+    await saveState(state);
+
+    if (themeSelect) {
+      themeSelect.value = state.settings?.theme ?? 'dark';
+    }
+
+    const note = diagnostics.length ? ` Fixes applied: ${diagnostics.join(' ')}` : '';
+    announce(`Import successful.${note}`, 'success');
+  } catch (error) {
+    console.error(error);
+    announce(error.message || 'Import failed.', 'error');
+  } finally {
+    input.value = '';
+  }
+}
+
+async function handleThemeChange(event) {
+  const selectedTheme = event.target.value;
+  if (!['dark', 'light', 'system'].includes(selectedTheme)) {
+    announce('Unknown theme selected.', 'error');
+    return;
+  }
+
+  state = {
+    ...state,
+    settings: {
+      ...state.settings,
+      theme: selectedTheme,
+    },
+  };
+  await saveState(state);
+  announce(`Theme updated to “${selectedTheme}”.`, 'success');
+}

--- a/sidepanel/app.js
+++ b/sidepanel/app.js
@@ -1,1 +1,15 @@
-import {loadState,saveState,initDefault} from './state.js';import {renderBoard} from './board.js';let s=await loadState()||await initDefault();renderBoard(s,{onState:async(n)=>{s=n;await saveState(s);renderBoard(s,{onState})}});
+import { loadState, saveState, initDefault } from './state.js';
+import { renderBoard } from './board.js';
+
+let state = await loadState();
+if (!state) {
+  state = await initDefault();
+}
+
+async function handleState(nextState) {
+  state = nextState;
+  await saveState(state);
+  renderBoard(state, { onState: handleState });
+}
+
+renderBoard(state, { onState: handleState });

--- a/sidepanel/board.js
+++ b/sidepanel/board.js
@@ -1,1 +1,352 @@
-import {html,cardView} from './templates.js';export function renderBoard(s,{onState}){const r=document.getElementById('board');const b=s.boards.find(x=>x.id===s.activeBoardId);r.innerHTML=b.columns.map(c=>`<section class='column'><div class='col-head'>${c.name}</div><div class='card-list' data-col-id='${c.id}'></div><button class='add-card' data-col-id='${c.id}'>+ Add</button></section>`).join('');}
+import { html, cardView, columnView } from './templates.js';
+import { createId } from './state.js';
+
+const boardRoot = document.getElementById('board');
+const searchInput = document.getElementById('search');
+const addColumnButton = document.getElementById('addColumn');
+
+let activeState = null;
+let activeHandlers = null;
+let listenersBound = false;
+let dragContext = null;
+let fixingActiveBoard = false;
+
+export function renderBoard(state, handlers) {
+  activeState = state;
+  activeHandlers = handlers;
+
+  if (!boardRoot) {
+    return;
+  }
+
+  bindEventListeners();
+
+  const board = resolveActiveBoard(state);
+  if (!board) {
+    renderEmptyState('Create a board from the options page to get started.');
+    return;
+  }
+
+  const query = (searchInput?.value ?? '').trim().toLowerCase();
+  const columns = Array.isArray(board.columns) ? board.columns : [];
+  const columnsMarkup = columns.map((column) => renderColumn(column, query));
+
+  if (columnsMarkup.length === 0) {
+    boardRoot.innerHTML = html`
+      <div class="empty-board" role="status">
+        This board has no columns yet. Use the “+ Column” button to add your first list.
+      </div>
+    `;
+  } else {
+    boardRoot.innerHTML = html`${columnsMarkup}`;
+  }
+
+  boardRoot.dataset.activeBoardId = board.id;
+}
+
+function bindEventListeners() {
+  if (listenersBound || !boardRoot) {
+    return;
+  }
+  listenersBound = true;
+
+  if (searchInput) {
+    searchInput.addEventListener('input', () => {
+      if (activeState) {
+        renderBoard(activeState, activeHandlers);
+      }
+    });
+  }
+
+  if (addColumnButton) {
+    addColumnButton.addEventListener('click', async () => {
+      if (!activeState) {
+        return;
+      }
+      const name = prompt('Column name');
+      if (!name || !name.trim()) {
+        return;
+      }
+      const trimmed = name.trim();
+      await updateBoard((board) => ({
+        ...board,
+        columns: [
+          ...board.columns,
+          { id: createId('column'), name: trimmed, cards: [] },
+        ],
+      }));
+    });
+  }
+
+  boardRoot.addEventListener('click', handleBoardClick);
+  boardRoot.addEventListener('dragstart', handleDragStart);
+  boardRoot.addEventListener('dragend', handleDragEnd);
+  boardRoot.addEventListener('dragenter', handleDragEnter);
+  boardRoot.addEventListener('dragover', handleDragOver);
+  boardRoot.addEventListener('dragleave', handleDragLeave);
+  boardRoot.addEventListener('drop', handleDrop);
+}
+
+function resolveActiveBoard(state) {
+  if (!state || !Array.isArray(state.boards) || state.boards.length === 0) {
+    delete boardRoot.dataset.activeBoardId;
+    return null;
+  }
+
+  const board = state.boards.find((item) => item.id === state.activeBoardId);
+  if (board) {
+    return board;
+  }
+
+  if (!fixingActiveBoard && activeHandlers?.onState) {
+    fixingActiveBoard = true;
+    const fallbackState = { ...state, activeBoardId: state.boards[0].id };
+    Promise.resolve(activeHandlers.onState(fallbackState)).finally(() => {
+      fixingActiveBoard = false;
+    });
+  }
+
+  delete boardRoot.dataset.activeBoardId;
+  return null;
+}
+
+function renderEmptyState(message) {
+  if (!boardRoot) {
+    return;
+  }
+  boardRoot.innerHTML = html`
+    <div class="empty-state" role="status">
+      ${message}
+    </div>
+  `;
+  delete boardRoot.dataset.activeBoardId;
+}
+
+function renderColumn(column, query) {
+  const cards = Array.isArray(column.cards) ? column.cards : [];
+  const visibleCards = query
+    ? cards.filter((card) => matchesQuery(card, query))
+    : cards;
+
+  const cardsMarkup = visibleCards.length
+    ? visibleCards.map((card) => cardView(card, { query }))
+    : html`<div class="empty-column" role="note">${query ? 'No cards match this search.' : 'No cards yet.'}</div>`;
+
+  return columnView(column, {
+    cardsMarkup,
+    visibleCount: visibleCards.length,
+    totalCount: cards.length,
+    queryActive: Boolean(query),
+  });
+}
+
+function matchesQuery(card, query) {
+  const title = (card.title ?? '').toLowerCase();
+  const description = (card.description ?? '').toLowerCase();
+  return title.includes(query) || description.includes(query);
+}
+
+async function updateBoard(mutator) {
+  if (!activeState || !activeHandlers?.onState) {
+    return;
+  }
+
+  const boardIndex = activeState.boards.findIndex((board) => board.id === activeState.activeBoardId);
+  if (boardIndex === -1) {
+    return;
+  }
+
+  const currentBoard = activeState.boards[boardIndex];
+  const nextBoard = await mutator(currentBoard);
+  if (!nextBoard || nextBoard === currentBoard) {
+    return;
+  }
+
+  const nextBoards = activeState.boards.map((board, index) => (index === boardIndex ? nextBoard : board));
+  const nextState = { ...activeState, boards: nextBoards };
+  activeState = nextState;
+  await activeHandlers.onState(nextState);
+}
+
+async function handleBoardClick(event) {
+  const addButton = event.target instanceof HTMLElement ? event.target.closest('.add-card') : null;
+  if (!addButton) {
+    return;
+  }
+
+  const columnId = addButton.dataset.colId;
+  if (!columnId) {
+    return;
+  }
+
+  const columnTitle = addButton.closest('.column')?.querySelector('.column-title')?.textContent ?? 'column';
+  const title = prompt(`New card title for ${columnTitle}`);
+  if (!title || !title.trim()) {
+    return;
+  }
+
+  const trimmed = title.trim();
+  await updateBoard((board) => {
+    const nextColumns = board.columns.map((column) => {
+      if (column.id !== columnId) {
+        return column;
+      }
+      return {
+        ...column,
+        cards: [
+          ...column.cards,
+          { id: createId('card'), title: trimmed, description: '' },
+        ],
+      };
+    });
+    return { ...board, columns: nextColumns };
+  });
+}
+
+function handleDragStart(event) {
+  const cardElement = event.target instanceof HTMLElement ? event.target.closest('.card') : null;
+  if (!cardElement) {
+    return;
+  }
+
+  const columnElement = cardElement.closest('.column');
+  if (!columnElement) {
+    return;
+  }
+
+  dragContext = {
+    cardId: cardElement.dataset.cardId,
+    fromColumnId: columnElement.dataset.columnId,
+  };
+
+  if (event.dataTransfer && dragContext.cardId) {
+    event.dataTransfer.effectAllowed = 'move';
+    event.dataTransfer.setData('text/plain', dragContext.cardId);
+  }
+
+  cardElement.classList.add('dragging');
+}
+
+function handleDragEnd(event) {
+  const cardElement = event.target instanceof HTMLElement ? event.target.closest('.card') : null;
+  if (cardElement) {
+    cardElement.classList.remove('dragging');
+  }
+  dragContext = null;
+  clearDropIndicators();
+}
+
+function handleDragEnter(event) {
+  if (!dragContext) {
+    return;
+  }
+  const list = event.target instanceof HTMLElement ? event.target.closest('.card-list') : null;
+  if (list) {
+    list.classList.add('drop-target');
+  }
+}
+
+function handleDragOver(event) {
+  if (!dragContext) {
+    return;
+  }
+  const list = event.target instanceof HTMLElement ? event.target.closest('.card-list') : null;
+  if (!list) {
+    return;
+  }
+  event.preventDefault();
+  if (event.dataTransfer) {
+    event.dataTransfer.dropEffect = 'move';
+  }
+}
+
+function handleDragLeave(event) {
+  const list = event.target instanceof HTMLElement ? event.target.closest('.card-list') : null;
+  if (!list) {
+    return;
+  }
+  const related = event.relatedTarget instanceof HTMLElement ? event.relatedTarget : null;
+  if (!related || !list.contains(related)) {
+    list.classList.remove('drop-target');
+  }
+}
+
+function handleDrop(event) {
+  if (!dragContext) {
+    return;
+  }
+
+  const list = event.target instanceof HTMLElement ? event.target.closest('.card-list') : null;
+  if (!list) {
+    return;
+  }
+  event.preventDefault();
+
+  const toColumnId = list.dataset.colId;
+  const beforeCard = event.target instanceof HTMLElement ? event.target.closest('.card') : null;
+  const beforeCardId = beforeCard?.dataset.cardId ?? null;
+
+  const { cardId, fromColumnId } = dragContext;
+  dragContext = null;
+  clearDropIndicators();
+
+  if (!cardId || !fromColumnId || !toColumnId) {
+    return;
+  }
+
+  void updateBoard((board) => moveCard(board, cardId, fromColumnId, toColumnId, beforeCardId));
+}
+
+function moveCard(board, cardId, fromColumnId, toColumnId, beforeCardId) {
+  let cardToMove = null;
+
+  const columnsWithoutCard = board.columns.map((column) => {
+    if (column.id !== fromColumnId) {
+      return column;
+    }
+    const remaining = [];
+    for (const card of column.cards) {
+      if (card.id === cardId) {
+        cardToMove = card;
+      } else {
+        remaining.push(card);
+      }
+    }
+    if (cardToMove) {
+      return { ...column, cards: remaining };
+    }
+    return column;
+  });
+
+  if (!cardToMove) {
+    return board;
+  }
+
+  const targetColumnId = toColumnId || fromColumnId;
+  const updatedColumns = columnsWithoutCard.map((column) => {
+    if (column.id !== targetColumnId) {
+      return column;
+    }
+    const nextCards = column.cards.slice();
+    let insertIndex = nextCards.length;
+    if (beforeCardId) {
+      const index = nextCards.findIndex((card) => card.id === beforeCardId);
+      if (index !== -1) {
+        insertIndex = index;
+      }
+    }
+    nextCards.splice(insertIndex, 0, cardToMove);
+    return { ...column, cards: nextCards };
+  });
+
+  return { ...board, columns: updatedColumns };
+}
+
+function clearDropIndicators() {
+  if (!boardRoot) {
+    return;
+  }
+  boardRoot.querySelectorAll('.drop-target').forEach((element) => {
+    element.classList.remove('drop-target');
+  });
+}

--- a/sidepanel/state.js
+++ b/sidepanel/state.js
@@ -1,1 +1,303 @@
-const KEY='kanban.v1';export async function loadState(){const { [KEY]:d }=await chrome.storage.local.get(KEY);return d||null;}export async function saveState(s){await chrome.storage.local.set({[KEY]:s});}export async function initDefault(){const b={version:1,boards:[{id:'default',name:'My Board',labels:[],columns:[{id:'c1',name:'Backlog'},{id:'c2',name:'Doing'},{id:'c3',name:'Done'}],cards:[]}],activeBoardId:'default',settings:{theme:'dark'}};await saveState(b);return b;}
+const STORAGE_KEY = 'kanban.v1';
+const ALLOWED_THEMES = new Set(['dark', 'light', 'system']);
+
+const DEFAULT_BOARD = Object.freeze({
+  id: 'board-default',
+  name: 'My Board',
+  labels: [],
+  columns: [
+    {
+      id: 'col-backlog',
+      name: 'Backlog',
+      cards: [
+        {
+          id: 'card-welcome',
+          title: 'Welcome to cm-kanban',
+          description: 'Use "+ Column" to add more lists and start capturing your ideas.',
+        },
+      ],
+    },
+    {
+      id: 'col-progress',
+      name: 'In Progress',
+      cards: [
+        {
+          id: 'card-drag',
+          title: 'Drag cards between columns',
+          description: 'Grab a card, move it to a new status, and drop it where it belongs.',
+        },
+      ],
+    },
+    {
+      id: 'col-done',
+      name: 'Done',
+      cards: [
+        {
+          id: 'card-search',
+          title: 'Try the search bar',
+          description: 'Filter cards instantly by typing a keyword at the top of the panel.',
+        },
+      ],
+    },
+  ],
+});
+
+const DEFAULT_STATE = Object.freeze({
+  version: 1,
+  boards: [DEFAULT_BOARD],
+  activeBoardId: DEFAULT_BOARD.id,
+  settings: {
+    theme: 'dark',
+  },
+});
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+export function createDefaultBoard() {
+  return clone(DEFAULT_BOARD);
+}
+
+export function createDefaultState() {
+  return clone(DEFAULT_STATE);
+}
+
+export function createId(prefix = 'id') {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return `${prefix}-${crypto.randomUUID()}`;
+  }
+  const random = Math.random().toString(36).slice(2, 10);
+  const timestamp = Date.now().toString(36);
+  return `${prefix}-${timestamp}${random}`;
+}
+
+function isPlainObject(value) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function normalizeCard(card, index, diagnostics, boardName, columnName, tracker) {
+  if (!isPlainObject(card)) {
+    tracker.changed = true;
+    diagnostics.push(`Removed invalid card at position ${index + 1} in "${columnName}" on "${boardName}".`);
+    return null;
+  }
+
+  const idSource = typeof card.id === 'string' ? card.id.trim() : '';
+  const id = idSource || createId('card');
+  if (id !== card.id) {
+    tracker.changed = true;
+  }
+
+  const titleSource = typeof card.title === 'string' ? card.title.trim() : '';
+  const title = titleSource || 'Untitled card';
+  if (title !== card.title) {
+    tracker.changed = true;
+  }
+
+  const description = typeof card.description === 'string' ? card.description : '';
+  if (description !== card.description) {
+    tracker.changed = true;
+  }
+
+  return { id, title, description };
+}
+
+function normalizeColumn(column, index, diagnostics, boardName, tracker) {
+  if (!isPlainObject(column)) {
+    tracker.changed = true;
+    diagnostics.push(`Removed invalid column at position ${index + 1} on "${boardName}".`);
+    return null;
+  }
+
+  const nameSource = typeof column.name === 'string' ? column.name.trim() : '';
+  const name = nameSource || `Column ${index + 1}`;
+  if (name !== column.name) {
+    tracker.changed = true;
+  }
+
+  const idSource = typeof column.id === 'string' ? column.id.trim() : '';
+  const id = idSource || createId('column');
+  if (id !== column.id) {
+    tracker.changed = true;
+  }
+
+  const normalized = {
+    id,
+    name,
+    cards: [],
+  };
+
+  const cardsSource = Array.isArray(column.cards) ? column.cards : [];
+  if (!Array.isArray(column.cards)) {
+    tracker.changed = true;
+    diagnostics.push(`Column "${name}" on "${boardName}" was missing cards; initialized an empty list.`);
+  }
+
+  for (let i = 0; i < cardsSource.length; i += 1) {
+    const card = normalizeCard(cardsSource[i], i, diagnostics, boardName, name, tracker);
+    if (card) {
+      normalized.cards.push(card);
+    }
+  }
+
+  if (normalized.cards.length !== cardsSource.length) {
+    tracker.changed = true;
+  }
+
+  return normalized;
+}
+
+function normalizeBoard(board, index, diagnostics, tracker) {
+  if (!isPlainObject(board)) {
+    tracker.changed = true;
+    diagnostics.push(`Removed invalid board at position ${index + 1}.`);
+    return null;
+  }
+
+  const nameSource = typeof board.name === 'string' ? board.name.trim() : '';
+  const name = nameSource || `Board ${index + 1}`;
+  if (name !== board.name) {
+    tracker.changed = true;
+  }
+
+  const idSource = typeof board.id === 'string' ? board.id.trim() : '';
+  const id = idSource || createId('board');
+  if (id !== board.id) {
+    tracker.changed = true;
+  }
+
+  const labels = Array.isArray(board.labels) ? board.labels.filter((label) => typeof label === 'string') : [];
+  if (!Array.isArray(board.labels) || labels.length !== board.labels.length) {
+    tracker.changed = true;
+  }
+
+  const normalized = {
+    id,
+    name,
+    labels,
+    columns: [],
+  };
+
+  let columnsSource = Array.isArray(board.columns) ? board.columns : [];
+  if (!Array.isArray(board.columns) || board.columns.length === 0) {
+    tracker.changed = true;
+    diagnostics.push(`Board "${name}" was missing columns; added defaults.`);
+    columnsSource = createDefaultBoard().columns;
+  }
+
+  for (let i = 0; i < columnsSource.length; i += 1) {
+    const column = normalizeColumn(columnsSource[i], i, diagnostics, name, tracker);
+    if (column) {
+      normalized.columns.push(column);
+    }
+  }
+
+  if (normalized.columns.length === 0) {
+    tracker.changed = true;
+    diagnostics.push(`Board "${name}" had no valid columns; added defaults.`);
+    normalized.columns = createDefaultBoard().columns;
+  }
+
+  return normalized;
+}
+
+export function normalizeState(rawState) {
+  const diagnostics = [];
+  const tracker = { changed: false };
+
+  if (!isPlainObject(rawState)) {
+    diagnostics.push('State was empty or invalid; replaced with defaults.');
+    return { state: createDefaultState(), changed: true, diagnostics };
+  }
+
+  const normalized = {
+    version: 1,
+    boards: [],
+    activeBoardId: '',
+    settings: {
+      theme: 'dark',
+    },
+  };
+
+  if (rawState.version !== 1) {
+    tracker.changed = true;
+  }
+
+  const boardsSource = Array.isArray(rawState.boards) ? rawState.boards : [];
+  if (!Array.isArray(rawState.boards)) {
+    tracker.changed = true;
+    diagnostics.push('State was missing boards; added default board.');
+  }
+
+  for (let i = 0; i < boardsSource.length; i += 1) {
+    const board = normalizeBoard(boardsSource[i], i, diagnostics, tracker);
+    if (board) {
+      normalized.boards.push(board);
+    }
+  }
+
+  if (normalized.boards.length === 0) {
+    tracker.changed = true;
+    diagnostics.push('No usable boards found; added default board.');
+    normalized.boards.push(createDefaultBoard());
+  }
+
+  const requestedBoardId = typeof rawState.activeBoardId === 'string' && rawState.activeBoardId.trim()
+    ? rawState.activeBoardId.trim()
+    : '';
+  const hasRequestedBoard = normalized.boards.some((board) => board.id === requestedBoardId);
+  normalized.activeBoardId = hasRequestedBoard ? requestedBoardId : normalized.boards[0].id;
+  if (!hasRequestedBoard) {
+    tracker.changed = true;
+    diagnostics.push('Active board was missing or invalid; switched to the first available board.');
+  }
+
+  if (isPlainObject(rawState.settings) && typeof rawState.settings.theme === 'string') {
+    const normalizedTheme = rawState.settings.theme.trim().toLowerCase();
+    if (ALLOWED_THEMES.has(normalizedTheme)) {
+      normalized.settings.theme = normalizedTheme;
+      if (normalized.settings.theme !== rawState.settings.theme) {
+        tracker.changed = true;
+      }
+    } else {
+      tracker.changed = true;
+      diagnostics.push('Theme value was invalid; reverted to "dark".');
+    }
+  } else if (rawState.settings !== undefined) {
+    tracker.changed = true;
+    diagnostics.push('Settings were malformed; reset to defaults.');
+  }
+
+  return {
+    state: normalized,
+    changed: tracker.changed,
+    diagnostics,
+  };
+}
+
+export async function loadState() {
+  const stored = await chrome.storage.local.get(STORAGE_KEY);
+  const rawState = stored[STORAGE_KEY];
+  if (!rawState) {
+    return null;
+  }
+
+  const { state, changed } = normalizeState(rawState);
+  if (changed) {
+    await saveState(state);
+  }
+  return state;
+}
+
+export async function saveState(state) {
+  await chrome.storage.local.set({ [STORAGE_KEY]: state });
+}
+
+export async function initDefault() {
+  const state = createDefaultState();
+  await saveState(state);
+  return state;
+}
+
+export { STORAGE_KEY };

--- a/sidepanel/styles.css
+++ b/sidepanel/styles.css
@@ -1,1 +1,221 @@
-:root{color-scheme:dark;}body{margin:0;font:14px system-ui;background:#0f1115;color:#e6e6e6}
+:root {
+  color-scheme: dark;
+  --background: #0f1115;
+  --surface: #151822;
+  --surface-elevated: #1d2130;
+  --surface-highlight: #2f80ed33;
+  --border: #1f2330;
+  --accent: #2f80ed;
+  --text: #e6e6e6;
+  --text-muted: #9aa1b9;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  font: 14px/1.5 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  background: var(--background);
+  color: var(--text);
+}
+
+header {
+  position: sticky;
+  top: 0;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 16px;
+  background: rgba(15, 17, 21, 0.92);
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid var(--border);
+  z-index: 1;
+}
+
+header h1 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+#search {
+  flex: 1;
+  min-width: 140px;
+  max-width: 320px;
+  padding: 8px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: inherit;
+  outline: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+#search:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(47, 128, 237, 0.25);
+}
+
+button {
+  border: none;
+  border-radius: 8px;
+  background: var(--accent);
+  color: #fff;
+  padding: 8px 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+button:hover {
+  background: #4d96f3;
+}
+
+button:active {
+  transform: translateY(1px);
+}
+
+main#board {
+  flex: 1;
+  display: flex;
+  gap: 16px;
+  padding: 16px;
+  overflow-x: auto;
+  align-items: flex-start;
+}
+
+.column {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 260px;
+  max-width: 280px;
+  max-height: calc(100vh - 120px);
+  background: var(--surface);
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.25);
+}
+
+.column-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 16px 10px;
+  border-bottom: 1px solid var(--border);
+}
+
+.column-title {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.column-meta {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.card-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 12px 16px;
+  overflow-y: auto;
+}
+
+.card {
+  background: var(--surface-elevated);
+  border-radius: 10px;
+  padding: 12px 14px;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.35);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+  cursor: grab;
+}
+
+.card:active {
+  cursor: grabbing;
+}
+
+.card.dragging {
+  opacity: 0.4;
+  box-shadow: 0 0 0 rgba(0, 0, 0, 0);
+}
+
+.card-title {
+  margin: 0 0 6px;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.card-body {
+  margin: 0;
+  font-size: 13px;
+  color: #c9cedd;
+}
+
+.add-card {
+  margin: 0 16px 16px;
+  padding: 10px;
+  border-radius: 10px;
+  border: 1px dashed var(--border);
+  background: transparent;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.add-card:hover {
+  border-color: var(--accent);
+  color: #fff;
+  background: rgba(47, 128, 237, 0.08);
+}
+
+.empty-column {
+  padding: 20px 16px;
+  border-radius: 10px;
+  background: rgba(21, 24, 34, 0.8);
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.empty-board,
+.empty-state {
+  margin: auto;
+  max-width: 320px;
+  padding: 32px;
+  border-radius: 16px;
+  background: rgba(21, 24, 34, 0.85);
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  text-align: center;
+  line-height: 1.6;
+}
+
+.card-list.drop-target {
+  outline: 2px dashed var(--accent);
+  outline-offset: -8px;
+  background: rgba(47, 128, 237, 0.08);
+}
+
+mark {
+  background: var(--surface-highlight);
+  color: inherit;
+  padding: 0 2px;
+  border-radius: 4px;
+}
+
+@media (max-width: 640px) {
+  header {
+    flex-wrap: wrap;
+  }
+
+  #search {
+    flex-basis: 100%;
+  }
+}

--- a/sidepanel/templates.js
+++ b/sidepanel/templates.js
@@ -1,0 +1,114 @@
+class RawString {
+  constructor(value) {
+    this.value = String(value);
+  }
+}
+
+function escapeHtml(value) {
+  return String(value).replace(/[&<>"]/g, (char) => {
+    switch (char) {
+      case '&':
+        return '&amp;';
+      case '<':
+        return '&lt;';
+      case '>':
+        return '&gt;';
+      case '"':
+        return '&quot;';
+      default:
+        return char;
+    }
+  }).replace(/'/g, '&#39;');
+}
+
+function normalizeValue(value) {
+  if (value === false || value === null || value === undefined) {
+    return '';
+  }
+
+  if (value instanceof RawString) {
+    return value.value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeValue(item)).join('');
+  }
+
+  return escapeHtml(value);
+}
+
+export function raw(value) {
+  return new RawString(value);
+}
+
+export function html(strings, ...values) {
+  let result = '';
+  for (let i = 0; i < strings.length; i += 1) {
+    result += strings[i];
+    if (i < values.length) {
+      result += normalizeValue(values[i]);
+    }
+  }
+  return result;
+}
+
+function highlightMarkup(text, query) {
+  const source = typeof text === 'string' ? text : '';
+  if (!query) {
+    return escapeHtml(source);
+  }
+
+  const lower = source.toLowerCase();
+  const term = query.toLowerCase();
+  const length = term.length;
+  if (!length || !lower.includes(term)) {
+    return escapeHtml(source);
+  }
+
+  let cursor = 0;
+  let output = '';
+  while (cursor < source.length) {
+    const index = lower.indexOf(term, cursor);
+    if (index === -1) {
+      output += escapeHtml(source.slice(cursor));
+      break;
+    }
+
+    output += escapeHtml(source.slice(cursor, index));
+    output += `<mark>${escapeHtml(source.slice(index, index + length))}</mark>`;
+    cursor = index + length;
+  }
+
+  return output;
+}
+
+export function cardView(card, { query } = {}) {
+  const titleMarkup = highlightMarkup(card.title ?? '', query);
+  const descriptionMarkup = card.description ? highlightMarkup(card.description, query) : '';
+
+  return html`
+    <article class="card" data-card-id="${card.id}" draggable="true">
+      <h3 class="card-title">${raw(titleMarkup)}</h3>
+      ${descriptionMarkup ? html`<p class="card-body">${raw(descriptionMarkup)}</p>` : ''}
+    </article>
+  `;
+}
+
+export function columnView(column, { cardsMarkup, visibleCount, totalCount, queryActive }) {
+  const countLabel = queryActive && typeof totalCount === 'number'
+    ? `${visibleCount}/${totalCount}`
+    : `${visibleCount}`;
+
+  return html`
+    <section class="column" data-column-id="${column.id}">
+      <header class="column-header">
+        <h2 class="column-title">${column.name}</h2>
+        <span class="column-meta" aria-label="${queryActive ? 'Visible cards out of total' : 'Card count'}">${countLabel}</span>
+      </header>
+      <div class="card-list" data-col-id="${column.id}">
+        ${cardsMarkup}
+      </div>
+      <button class="add-card" data-col-id="${column.id}" type="button">+ Add card</button>
+    </section>
+  `;
+}


### PR DESCRIPTION
## Summary
- add a reusable templating helper and rebuild the board renderer with card rendering, drag and drop, search, and column creation
- harden state initialization and loading by normalizing stored data and repairing invalid boards before rendering
- refresh styles and wire the options page with import validation and theme selection controls

## Testing
- not run (Chrome extension UI change)


------
https://chatgpt.com/codex/tasks/task_e_68e410d2eba48328ae250fe80d23068a