### PR TITLE
Fix popup card creation to target first column

### DIFF
--- a/popup/popup.js
+++ b/popup/popup.js
@@ -22,22 +22,28 @@ saveButton?.addEventListener('click', async () => {
   }
 
   if (!Array.isArray(board.columns) || board.columns.length === 0) {
-    const column = { id: crypto.randomUUID(), name: 'Backlog' };
+    const column = {
+      id: crypto.randomUUID(),
+      name: 'Backlog',
+      cards: [],
+    };
     board.columns = [column];
   }
 
-  if (!Array.isArray(board.cards)) {
-    board.cards = [];
+  const [firstColumn] = board.columns;
+
+  if (!Array.isArray(firstColumn.cards)) {
+    firstColumn.cards = [];
   }
 
   const titleInput = document.getElementById('title');
   const title = titleInput?.value?.trim();
   const cardTitle = title?.length ? title : 'New task';
 
-  board.cards.push({
+  firstColumn.cards.push({
     id: crypto.randomUUID(),
     title: cardTitle,
-    columnId: board.columns[0].id,
+    description: '',
   });
 
   await saveState(state);


### PR DESCRIPTION
## Summary
- ensure new cards created from the popup are stored in the first available column
- initialize a default column with an empty card list when none exist

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4151881048328ad5671762d1b490a