### PR TITLE
Ensure side panel opens before naming

### DIFF
--- a/background/service-worker.js
+++ b/background/service-worker.js
@@ -73,6 +73,26 @@ chrome.contextMenus.onClicked.addListener(async (info, tab) => {
   await chrome.storage.local.set({ [STORAGE_KEY]: state });
 });
 
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message?.type !== 'kanban/ensure-side-panel-open') {
+    return undefined;
+  }
+
+  const windowId = sender?.tab?.windowId ?? sender?.windowId ?? chrome.windows?.WINDOW_ID_CURRENT;
+
+  (async () => {
+    if (windowId !== undefined) {
+      await openSidePanel(windowId);
+    }
+    sendResponse();
+  })().catch((error) => {
+    console.warn('Failed to ensure side panel is open.', error);
+    sendResponse();
+  });
+
+  return true;
+});
+
 async function loadKanbanState() {
   const stored = await chrome.storage.local.get(STORAGE_KEY);
   const state = stored[STORAGE_KEY];

--- a/sidepanel/app.js
+++ b/sidepanel/app.js
@@ -54,7 +54,10 @@ async function requestKanbanName() {
     return;
   }
 
-  const response = prompt('Name your Kanban board', activeBoard.name ?? '');
+  await ensureSidePanelVisible();
+
+  const defaultName = activeBoard.name?.trim() || 'Kanban';
+  const response = prompt('Name your Kanban board', defaultName);
   const name = response?.trim();
   awaitingInitialBoard = false;
   if (!name || name === activeBoard.name) {
@@ -71,4 +74,16 @@ async function requestKanbanName() {
     ...state,
     boards: nextBoards,
   });
+}
+
+async function ensureSidePanelVisible() {
+  if (!chrome.runtime?.sendMessage) {
+    return;
+  }
+
+  try {
+    await chrome.runtime.sendMessage({ type: 'kanban/ensure-side-panel-open' });
+  } catch (error) {
+    console.warn('Unable to ensure side panel is open.', error);
+  }
 }


### PR DESCRIPTION
## Summary
- ensure the service worker can reopen the side panel when the UI requests visibility before prompting for a board name
- request the side panel to be opened prior to prompting and fall back to "Kanban" as the default name suggestion

## Testing
- not run (extension)

------
https://chatgpt.com/codex/tasks/task_e_68e41aa335f88328a98dc3d1dd4011e0