### PR TITLE
Stop prompting for Kanban name

### DIFF
--- a/sidepanel/state.js
+++ b/sidepanel/state.js
@@ -3,7 +3,7 @@ const ALLOWED_THEMES = new Set(['dark', 'light', 'system']);
 
 const DEFAULT_BOARD = Object.freeze({
   id: 'board-default',
-  name: 'My Board',
+  name: 'Kanban',
   labels: [],
   columns: [
     {
@@ -156,7 +156,8 @@ function normalizeBoard(board, index, diagnostics, tracker) {
   }
 
   const nameSource = typeof board.name === 'string' ? board.name.trim() : '';
-  const name = nameSource || `Board ${index + 1}`;
+  const fallbackName = index === 0 ? 'Kanban' : `Board ${index + 1}`;
+  const name = nameSource || fallbackName;
   if (name !== board.name) {
     tracker.changed = true;
   }


### PR DESCRIPTION
## Summary
- remove the name prompt and automatically initialise the first board when needed
- ensure the side panel still opens before using the board
- default the first board name to Kanban when missing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e43f1ab48c832887dc985d8fdf49dc