### PR TITLE
Initialize default Kanban before opening panel

### DIFF
--- a/background/service-worker.js
+++ b/background/service-worker.js
@@ -122,17 +122,17 @@ async function requestKanbanName(windowId, { ensureVisible = true } = {}) {
   const targetWindowId = windowId ?? chrome.windows?.WINDOW_ID_CURRENT;
   const existingState = await loadKanbanState();
 
-  if (existingState) {
-    if (ensureVisible && targetWindowId !== undefined) {
-      await openSidePanel(targetWindowId);
-    }
+  if (!existingState) {
+    await chrome.storage.local.set({ [STORAGE_KEY]: createDefaultState() });
+  }
+
+  if (!ensureVisible) {
     return;
   }
 
   let resolvedWindowId = targetWindowId;
   if (
     resolvedWindowId === undefined
-    && ensureVisible
     && chrome.windows?.getCurrent
   ) {
     try {
@@ -147,19 +147,5 @@ async function requestKanbanName(windowId, { ensureVisible = true } = {}) {
 
   if (resolvedWindowId !== undefined) {
     await openSidePanel(resolvedWindowId);
-  }
-
-  let initializedViaPanel = false;
-  if (chrome.runtime?.sendMessage) {
-    try {
-      await chrome.runtime.sendMessage({ type: 'kanban/request-name' });
-      initializedViaPanel = true;
-    } catch (error) {
-      console.warn('Unable to request Kanban name from side panel.', error);
-    }
-  }
-
-  if (!initializedViaPanel) {
-    await chrome.storage.local.set({ [STORAGE_KEY]: createDefaultState() });
   }
 }


### PR DESCRIPTION
## Summary
- initialize the default Kanban state as soon as no stored board exists
- skip the name request prompt and simply open the side panel for the current window

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4636aaf188328a69d123d2e63d716