### PR TITLE
Fix Kanban side panel rendering and add layout styling

### DIFF
--- a/sidepanel/board.js
+++ b/sidepanel/board.js
@@ -1,1 +1,243 @@
-import {html,cardView} from './templates.js';export function renderBoard(s,{onState}){const r=document.getElementById('board');const b=s.boards.find(x=>x.id===s.activeBoardId);r.innerHTML=b.columns.map(c=>`<section class='column'><div class='col-head'>${c.name}</div><div class='card-list' data-col-id='${c.id}'></div><button class='add-card' data-col-id='${c.id}'>+ Add</button></section>`).join('');}
+const boardEl = document.getElementById('board');
+const searchInput = document.getElementById('search');
+const addColumnButton = document.getElementById('addColumn');
+
+let currentState = null;
+let onStateChange = null;
+let searchTermRaw = '';
+let draggingCardId = null;
+
+if (searchInput && !searchInput.dataset.bound) {
+  searchInput.dataset.bound = 'true';
+  searchInput.addEventListener('input', handleSearchInput);
+}
+
+if (addColumnButton && !addColumnButton.dataset.bound) {
+  addColumnButton.dataset.bound = 'true';
+  addColumnButton.addEventListener('click', handleAddColumn);
+}
+
+export function renderBoard(state, { onState }) {
+  currentState = state;
+  onStateChange = onState;
+
+  if (!boardEl) {
+    return;
+  }
+
+  const activeBoard = state.boards.find((board) => board.id === state.activeBoardId);
+
+  if (!activeBoard) {
+    boardEl.innerHTML = "<p class='empty'>Create a board from the options page.</p>";
+    return;
+  }
+
+  if (searchInput && searchInput.value !== searchTermRaw) {
+    searchInput.value = searchTermRaw;
+  }
+
+  const cardsByColumn = groupCardsByColumn(activeBoard.cards, searchTermRaw);
+
+  boardEl.innerHTML = activeBoard.columns
+    .map((column) => renderColumn(column, cardsByColumn.get(column.id) ?? []))
+    .join('');
+
+  bindColumnInteractions();
+}
+
+function handleSearchInput(event) {
+  searchTermRaw = event.target.value;
+
+  if (currentState && onStateChange) {
+    renderBoard(currentState, { onState: onStateChange });
+  }
+}
+
+function handleAddColumn() {
+  if (!currentState || !onStateChange) {
+    return;
+  }
+
+  const name = prompt('Column name?', '');
+
+  if (name === null) {
+    return;
+  }
+
+  const nextState = cloneState(currentState);
+  const board = nextState.boards.find((item) => item.id === nextState.activeBoardId);
+
+  if (!board) {
+    return;
+  }
+
+  board.columns.push({ id: crypto.randomUUID(), name: name.trim() || 'New Column' });
+  onStateChange(nextState);
+}
+
+function bindColumnInteractions() {
+  if (!boardEl) {
+    return;
+  }
+
+  boardEl.querySelectorAll('.add-card').forEach((button) => {
+    if (button.dataset.bound) {
+      return;
+    }
+
+    button.dataset.bound = 'true';
+    button.addEventListener('click', () => handleAddCard(button.dataset.colId));
+  });
+
+  boardEl.querySelectorAll('.card').forEach((card) => {
+    card.addEventListener('dragstart', handleDragStart);
+    card.addEventListener('dragend', handleDragEnd);
+  });
+
+  boardEl.querySelectorAll('.card-list').forEach((list) => {
+    list.addEventListener('dragover', handleDragOver);
+    list.addEventListener('drop', handleDrop);
+  });
+}
+
+function handleAddCard(columnId) {
+  if (!currentState || !onStateChange || !columnId) {
+    return;
+  }
+
+  const title = prompt('Card title?', '');
+
+  if (title === null) {
+    return;
+  }
+
+  const nextState = cloneState(currentState);
+  const board = nextState.boards.find((item) => item.id === nextState.activeBoardId);
+
+  if (!board) {
+    return;
+  }
+
+  board.cards.push({
+    id: crypto.randomUUID(),
+    title: title.trim() || 'New card',
+    columnId,
+  });
+
+  onStateChange(nextState);
+}
+
+function handleDragStart(event) {
+  draggingCardId = event.currentTarget.dataset.cardId || null;
+
+  if (!draggingCardId) {
+    return;
+  }
+
+  event.dataTransfer.effectAllowed = 'move';
+  event.dataTransfer.setData('text/plain', draggingCardId);
+}
+
+function handleDragEnd() {
+  draggingCardId = null;
+}
+
+function handleDragOver(event) {
+  event.preventDefault();
+  event.dataTransfer.dropEffect = 'move';
+}
+
+function handleDrop(event) {
+  event.preventDefault();
+
+  const columnId = event.currentTarget.dataset.colId;
+
+  if (!columnId || !draggingCardId || !currentState || !onStateChange) {
+    return;
+  }
+
+  const nextState = cloneState(currentState);
+  const board = nextState.boards.find((item) => item.id === nextState.activeBoardId);
+
+  if (!board) {
+    draggingCardId = null;
+    return;
+  }
+
+  const index = board.cards.findIndex((card) => card.id === draggingCardId);
+
+  if (index === -1) {
+    draggingCardId = null;
+    return;
+  }
+
+  const [card] = board.cards.splice(index, 1);
+  card.columnId = columnId;
+  board.cards.push(card);
+
+  draggingCardId = null;
+  onStateChange(nextState);
+}
+
+function renderColumn(column, cards) {
+  const cardMarkup = cards.length
+    ? cards.map(renderCard).join('')
+    : "<p class='empty'>No cards</p>";
+
+  return `
+    <section class="column">
+      <div class="col-head">${escapeHtml(column.name)}</div>
+      <div class="card-list" data-col-id="${column.id}">
+        ${cardMarkup}
+      </div>
+      <button class="add-card" data-col-id="${column.id}">+ Add</button>
+    </section>
+  `;
+}
+
+function renderCard(card) {
+  return `
+    <article class="card" draggable="true" data-card-id="${card.id}">
+      <div class="card-title">${escapeHtml(card.title)}</div>
+    </article>
+  `;
+}
+
+function groupCardsByColumn(cards, term) {
+  const matcher = term ? term.trim().toLowerCase() : '';
+  const grouped = new Map();
+
+  cards.forEach((card) => {
+    if (matcher && !card.title.toLowerCase().includes(matcher)) {
+      return;
+    }
+
+    if (!grouped.has(card.columnId)) {
+      grouped.set(card.columnId, []);
+    }
+
+    grouped.get(card.columnId).push(card);
+  });
+
+  return grouped;
+}
+
+function escapeHtml(value) {
+  return String(value ?? '').replace(/[&<>'"]/g, (char) =>
+    ({
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      "'": '&#39;',
+      '"': '&quot;',
+    })[char]
+  );
+}
+
+function cloneState(state) {
+  if (typeof structuredClone === 'function') {
+    return structuredClone(state);
+  }
+
+  return JSON.parse(JSON.stringify(state));
+}

--- a/sidepanel/styles.css
+++ b/sidepanel/styles.css
@@ -1,1 +1,136 @@
-:root{color-scheme:dark;}body{margin:0;font:14px system-ui;background:#0f1115;color:#e6e6e6}
+:root {
+  color-scheme: dark;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font: 14px/1.4 system-ui;
+  background: #0f1115;
+  color: #e6e6e6;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  background: #13161d;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+header h1 {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+header input {
+  flex: 1;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  background: #0f1115;
+  color: inherit;
+  padding: 0.4rem 0.6rem;
+}
+
+header button {
+  border: none;
+  background: #3a82f7;
+  color: white;
+  border-radius: 8px;
+  padding: 0.45rem 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+header button:hover {
+  background: #2d6dd1;
+}
+
+#board {
+  flex: 1;
+  display: flex;
+  gap: 1rem;
+  padding: 1rem;
+  overflow-x: auto;
+  align-items: flex-start;
+}
+
+.column {
+  background: #181c25;
+  border-radius: 12px;
+  width: 220px;
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - 140px);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.35);
+}
+
+.col-head {
+  padding: 0.75rem 1rem;
+  font-weight: 600;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.card-list {
+  flex: 1;
+  padding: 0.75rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  overflow-y: auto;
+}
+
+.card {
+  background: #202632;
+  border-radius: 10px;
+  padding: 0.75rem;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
+  cursor: grab;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.card:active {
+  cursor: grabbing;
+  transform: translateY(1px);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.35);
+}
+
+.card-title {
+  margin: 0;
+  font-weight: 500;
+}
+
+.add-card {
+  margin: 0 1rem 1rem;
+  padding: 0.5rem;
+  border-radius: 999px;
+  border: 1px dashed rgba(255, 255, 255, 0.1);
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.add-card:hover {
+  background: rgba(255, 255, 255, 0.05);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.empty {
+  margin: 0;
+  color: rgba(230, 230, 230, 0.65);
+  font-size: 0.85rem;
+}
+
+.card-list .empty {
+  padding: 0.25rem 0;
+}


### PR DESCRIPTION
## Summary
- replace the missing board renderer with a full DOM implementation that wires search, add column/card, and drag-and-drop to state updates
- ensure the side panel can initialize without chrome storage data by cloning state safely and avoiding missing module errors
- add dark Kanban layout styling for columns, cards, and header controls

## Testing
- Viewed sidepanel/index.html in a stubbed browser environment


------
https://chatgpt.com/codex/tasks/task_e_68e464787af4832880328648315a5b3c