### PR TITLE
Add import capability to options page

### DIFF
--- a/options/options.html
+++ b/options/options.html
@@ -1,1 +1,39 @@
-<!doctype html><html><body><h2>Kanban Settings</h2><button id='export'>Export</button><input type='file' id='import' accept='application/json'><script type='module' src='options.js'></script></body></html>
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Kanban Settings</title>
+    <style>
+      body {
+        font: 14px/1.4 system-ui;
+        background: #0f1115;
+        color: #e6e6e6;
+        margin: 0;
+        padding: 1.5rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+      }
+
+      button,
+      input[type='file'] {
+        width: fit-content;
+      }
+
+      #status[data-tone='success'] {
+        color: #6edc82;
+      }
+
+      #status[data-tone='error'] {
+        color: #ff8d8d;
+      }
+    </style>
+  </head>
+  <body>
+    <h2>Kanban Settings</h2>
+    <button id="export">Export</button>
+    <input type="file" id="import" accept="application/json" />
+    <p id="status" role="status" aria-live="polite"></p>
+    <script type="module" src="options.js"></script>
+  </body>
+</html>

--- a/options/options.js
+++ b/options/options.js
@@ -1,1 +1,95 @@
-const KEY='kanban.v1';document.getElementById('export').addEventListener('click',async()=>{const s=(await chrome.storage.local.get(KEY))[KEY];const a=document.createElement('a');a.href=URL.createObjectURL(new Blob([JSON.stringify(s,null,2)],{type:'application/json'}));a.download='kanban.json';a.click();});
+const KEY = 'kanban.v1';
+const exportButton = document.getElementById('export');
+const importInput = document.getElementById('import');
+const statusEl = document.getElementById('status');
+
+exportButton?.addEventListener('click', handleExportClick);
+importInput?.addEventListener('change', handleImportChange);
+
+async function handleExportClick() {
+  const stored = await chrome.storage.local.get(KEY);
+  const state = stored[KEY];
+
+  if (state == null) {
+    showStatus('Nothing to export yet.', 'info');
+    return;
+  }
+
+  const blob = new Blob([JSON.stringify(state, null, 2)], {
+    type: 'application/json',
+  });
+
+  const download = document.createElement('a');
+  download.href = URL.createObjectURL(blob);
+  download.download = 'kanban.json';
+  download.click();
+
+  showStatus('Export ready.', 'info');
+}
+
+
+async function handleImportChange(event) {
+  const input = event.target;
+  const file = input.files?.[0];
+
+  if (!file) {
+    showStatus('No file selected.', 'error');
+    return;
+  }
+
+  try {
+    const text = await file.text();
+    const parsed = JSON.parse(text);
+
+    validateState(parsed);
+
+    await chrome.storage.local.set({ [KEY]: parsed });
+    showStatus('Import successful.', 'success');
+  } catch (error) {
+    console.error('Failed to import Kanban data', error);
+    showStatus('Import failed. Please select a valid Kanban export file.', 'error');
+  } finally {
+    input.value = '';
+  }
+}
+
+function validateState(value) {
+  if (!value || typeof value !== 'object') {
+    throw new Error('State must be an object.');
+  }
+
+  if (!Array.isArray(value.boards)) {
+    throw new Error('Missing boards.');
+  }
+
+  value.boards.forEach((board) => {
+    if (!board || typeof board !== 'object') {
+      throw new Error('Invalid board.');
+    }
+
+    if (!Array.isArray(board.columns)) {
+      throw new Error('Board missing columns.');
+    }
+
+    if (!Array.isArray(board.cards)) {
+      throw new Error('Board missing cards.');
+    }
+  });
+
+  if (typeof value.activeBoardId !== 'string') {
+    throw new Error('Missing active board reference.');
+  }
+}
+
+function showStatus(message, tone = 'info') {
+  if (!statusEl) {
+    return;
+  }
+
+  statusEl.textContent = message;
+  if (tone) {
+    statusEl.dataset.tone = tone;
+  } else {
+    delete statusEl.dataset.tone;
+  }
+}


### PR DESCRIPTION
## Summary
- restyle the options page to include a status area for user feedback
- implement JSON import handling with validation and success or error messaging
- keep the export action but provide clearer feedback when there is no saved data

## Testing
- Manual verification of options page in browser

------
https://chatgpt.com/codex/tasks/task_e_68e4fcaf7aa483289c7a2d0f82998d8c