### PR TITLE
Improve Kanban interactions and resilience

### DIFF
--- a/background/service-worker.js
+++ b/background/service-worker.js
@@ -1,1 +1,37 @@
-chrome.runtime.onInstalled.addListener(()=>chrome.contextMenus.create({id:'kanban-add',title:'Add to Kanban',contexts:['selection','page']}));chrome.contextMenus.onClicked.addListener(async(info,tab)=>{if(info.menuItemId!=='kanban-add')return;const s=(await chrome.storage.local.get('kanban.v1'))['kanban.v1'];if(!s)return;const b=s.boards.find(x=>x.id===s.activeBoardId);b.cards.push({id:crypto.randomUUID(),title:info.selectionText||tab.title,columnId:b.columns[0].id});await chrome.storage.local.set({'kanban.v1':s});});
+import { loadState, saveState, initDefault } from '../sidepanel/state.js';
+
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.contextMenus.create({
+    id: 'kanban-add',
+    title: 'Add to Kanban',
+    contexts: ['selection', 'page'],
+  });
+});
+
+chrome.contextMenus.onClicked.addListener(async (info, tab) => {
+  if (info.menuItemId !== 'kanban-add') {
+    return;
+  }
+
+  let state = await loadState();
+
+  if (!state) {
+    state = await initDefault();
+  }
+
+  const board = state.boards.find((item) => item.id === state.activeBoardId);
+
+  if (!board || board.columns.length === 0) {
+    return;
+  }
+
+  const title = info.selectionText?.trim() || tab?.title?.trim() || 'New card';
+
+  board.cards.push({
+    id: crypto.randomUUID(),
+    title,
+    columnId: board.columns[0].id,
+  });
+
+  await saveState(state);
+});

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -1,1 +1,43 @@
-import {loadState,saveState} from '../sidepanel/state.js';document.getElementById('save').addEventListener('click',async()=>{const s=await loadState();const b=s.boards.find(x=>x.id===s.activeBoardId);b.cards.push({id:crypto.randomUUID(),title:document.getElementById('title').value||'New task',columnId:b.columns[0].id});await saveState(s);window.close();});
+import { initDefault, loadState, saveState } from '../sidepanel/state.js';
+
+const titleInput = document.getElementById('title');
+const saveButton = document.getElementById('save');
+
+saveButton?.addEventListener('click', handleSaveClick);
+
+titleInput?.addEventListener('keydown', (event) => {
+  if (event.key === 'Enter') {
+    event.preventDefault();
+    saveButton?.click();
+  }
+});
+
+async function handleSaveClick() {
+  let state = await loadState();
+
+  if (!state) {
+    state = await initDefault();
+  }
+
+  const activeBoard = state.boards.find((board) => board.id === state.activeBoardId);
+
+  if (!activeBoard || activeBoard.columns.length === 0) {
+    return;
+  }
+
+  const title = titleInput?.value.trim();
+
+  if (!title) {
+    titleInput?.focus();
+    return;
+  }
+
+  activeBoard.cards.push({
+    id: crypto.randomUUID(),
+    title,
+    columnId: activeBoard.columns[0].id,
+  });
+
+  await saveState(state);
+  window.close();
+}

--- a/sidepanel/app.js
+++ b/sidepanel/app.js
@@ -1,1 +1,16 @@
-import {loadState,saveState,initDefault} from './state.js';import {renderBoard} from './board.js';let s=await loadState()||await initDefault();renderBoard(s,{onState:async(n)=>{s=n;await saveState(s);renderBoard(s,{onState})}});
+import { loadState, saveState, initDefault } from './state.js';
+import { renderBoard } from './board.js';
+
+let state = await loadState();
+
+if (!state) {
+  state = await initDefault();
+}
+
+async function handleStateChange(nextState) {
+  state = nextState;
+  await saveState(state);
+  renderBoard(state, { onState: handleStateChange });
+}
+
+renderBoard(state, { onState: handleStateChange });

--- a/sidepanel/board.js
+++ b/sidepanel/board.js
@@ -90,11 +90,34 @@ function bindColumnInteractions() {
   });
 
   boardEl.querySelectorAll('.card').forEach((card) => {
+    if (card.dataset.bound) {
+      return;
+    }
+
+    card.dataset.bound = 'true';
     card.addEventListener('dragstart', handleDragStart);
     card.addEventListener('dragend', handleDragEnd);
   });
 
+  boardEl.querySelectorAll('.card-delete').forEach((button) => {
+    if (button.dataset.bound) {
+      return;
+    }
+
+    button.dataset.bound = 'true';
+    button.addEventListener('click', (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      handleDeleteCard(button.dataset.cardId);
+    });
+  });
+
   boardEl.querySelectorAll('.card-list').forEach((list) => {
+    if (list.dataset.bound) {
+      return;
+    }
+
+    list.dataset.bound = 'true';
     list.addEventListener('dragover', handleDragOver);
     list.addEventListener('drop', handleDrop);
   });
@@ -124,6 +147,34 @@ function handleAddCard(columnId) {
     columnId,
   });
 
+  onStateChange(nextState);
+}
+
+function handleDeleteCard(cardId) {
+  if (!currentState || !onStateChange || !cardId) {
+    return;
+  }
+
+  const confirmed = confirm('Delete this card?');
+
+  if (!confirmed) {
+    return;
+  }
+
+  const nextState = cloneState(currentState);
+  const board = nextState.boards.find((item) => item.id === nextState.activeBoardId);
+
+  if (!board) {
+    return;
+  }
+
+  const index = board.cards.findIndex((card) => card.id === cardId);
+
+  if (index === -1) {
+    return;
+  }
+
+  board.cards.splice(index, 1);
   onStateChange(nextState);
 }
 
@@ -198,6 +249,15 @@ function renderColumn(column, cards) {
 function renderCard(card) {
   return `
     <article class="card" draggable="true" data-card-id="${card.id}">
+      <button
+        class="card-delete"
+        type="button"
+        data-card-id="${card.id}"
+        aria-label="Delete card"
+        title="Delete card"
+      >
+        ×
+      </button>
       <div class="card-title">${escapeHtml(card.title)}</div>
     </article>
   `;
@@ -230,7 +290,7 @@ function escapeHtml(value) {
       '>': '&gt;',
       "'": '&#39;',
       '"': '&quot;',
-    })[char]
+    })[char],
   );
 }
 

--- a/sidepanel/styles.css
+++ b/sidepanel/styles.css
@@ -96,6 +96,9 @@ header button:hover {
   box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
   cursor: grab;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
 }
 
 .card:active {
@@ -104,9 +107,28 @@ header button:hover {
   box-shadow: 0 6px 16px rgba(0, 0, 0, 0.35);
 }
 
+.card-delete {
+  border: none;
+  background: transparent;
+  color: rgba(230, 230, 230, 0.65);
+  cursor: pointer;
+  padding: 0.15rem 0.25rem;
+  border-radius: 4px;
+  line-height: 1;
+  font-size: 1rem;
+  flex-shrink: 0;
+}
+
+.card-delete:hover {
+  color: #ff8d8d;
+  background: rgba(255, 141, 141, 0.12);
+}
+
 .card-title {
   margin: 0;
   font-weight: 500;
+  flex: 1;
+  word-break: break-word;
 }
 
 .add-card {


### PR DESCRIPTION
## Summary
- ensure the side panel, popup, and context menu all bootstrap the default board state before mutating data and guard against missing boards or columns
- add a delete action for cards along with supporting styling so cards can be removed directly from the board
- enhance the quick-add popup with basic validation and keyboard submit support for smoother task capture

## Testing
- npm test *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68e50210bb4c8328ba5c21d8ca480f77